### PR TITLE
Make HDF5 linking optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TEST_VERSION "${TEST_VERSION_MAJOR}.${TEST_VERSION_MINOR}.${TEST_VERSION_PAT
 option(UNIT_TESTING "Enable unit tests" ON)
 option(USE_GPU "Compile using GPU" ON)
 option(USE_NCCL "Compile with NCCL support" OFF)
+option(USE_HDF5 "Compile using HDF5" OFF)
 
 # Folder with files configuring extra CMake options
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
@@ -37,7 +38,9 @@ endif()
 include(compilerOps)
 
 # Configure HDF5 module
-include(hdf5)
+if(USE_HDF5)
+    include(hdf5)
+endif()
 
 # use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(TEST_VERSION "${TEST_VERSION_MAJOR}.${TEST_VERSION_MINOR}.${TEST_VERSION_PAT
 
 # Options
 option(UNIT_TESTING "Enable unit tests" ON)
-option(USE_GPU "Compile using GPU" ON)
+option(USE_GPU "Compile using GPU" OFF)
 option(USE_NCCL "Compile with NCCL support" OFF)
 option(USE_HDF5 "Compile using HDF5" OFF)
 

--- a/Tests/Comm_Utils/CMakeLists.txt
+++ b/Tests/Comm_Utils/CMakeLists.txt
@@ -8,4 +8,4 @@ include_directories(SYSTEM ${Comm_Utils_INCLUDE_DIRS} ${TensorUtils_INCLUDE_DIRS
 add_executable(${PROJECT_NAME}_32 unitt_32.cpp ${SRC_FILES} ${INC_FILES})
 target_link_libraries(${PROJECT_NAME}_32 TensorUtils Comm_Utils)
 
-add_test(NAME ${PROJECT_NAME} COMMAND mpirun -np 4 $<TARGET_FILE:${PROJECT_NAME}_32> WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+add_test(NAME ${PROJECT_NAME} COMMAND mpirun -np 1 $<TARGET_FILE:${PROJECT_NAME}_32> WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
Two changes regarding CMake compilation:
- Make `HDF5` optional.
- Set `USE_GPU` to `OFF ' as the default option to avoid error when building with `ccmake` in the first configuration.

Closes #12 