### PR TITLE
49 guided dot product

### DIFF
--- a/Tests/ConjugateGradient/unitt_32.cpp
+++ b/Tests/ConjugateGradient/unitt_32.cpp
@@ -35,6 +35,11 @@ int main() {
         arrSize_loc = arrSize_perRank[client_rank];
     }
 
+    // No periodicity, so listEntries is just a list of 0 to arrSize_loc-1
+    uint32_t arrSizeList_loc = arrSize_loc;
+    uint32_t* listEntries = (uint32_t*)calloc(arrSizeList_loc, sizeof(uint32_t));
+    for (uint32_t i = 0; i < arrSizeList_loc; i++) listEntries[i] = i;
+
     if (world_rank == 0) printf("Running test with %d MPI ranks, array size %d per rank\n", client_size, arrSize_loc);
 
     // Generate data for test
@@ -46,8 +51,10 @@ int main() {
     }
 
     #ifdef USE_GPU
+        uint32_t* d_listEntries = DeviceMemory<uint32_t,float>::deviceCalloc(arrSizeList_loc);
         float* d_x0 = DeviceMemory<uint32_t,float>::deviceCalloc(arrSize_loc);
         float* d_b = DeviceMemory<uint32_t,float>::deviceCalloc(arrSize_loc);
+        DeviceMemory<uint32_t,float>::copyHostToDevice(arrSizeList_loc, listEntries, d_listEntries);
         DeviceMemory<uint32_t,float>::copyHostToDevice(arrSize_loc, x0, d_x0);
         DeviceMemory<uint32_t,float>::copyHostToDevice(arrSize_loc, b,  d_b);
     #endif
@@ -65,13 +72,13 @@ int main() {
     #endif
 
     // Plan the solver
-    ConjugateGradient<uint32_t, float> Solver(client_comm, arrSize_loc, mIters, tol);
+    ConjugateGradient<uint32_t, float> Solver(client_comm, arrSize_loc, arrSizeList_loc, mIters, tol);
 
     // Setup the solver
     #if defined(USE_GPU)
-        Solver.setup(d_x0, d_b);
+        Solver.setup(d_listEntries, d_x0, d_b);
     #else
-        Solver.setup(x0, b);
+        Solver.setup(listEntries, x0, b);
     #endif
 
     // Run the solver

--- a/Tests/ConjugateGradient/unitt_32.cpp
+++ b/Tests/ConjugateGradient/unitt_32.cpp
@@ -51,10 +51,10 @@ int main() {
     }
 
     #ifdef USE_GPU
-        uint32_t* d_listEntries = DeviceMemory<uint32_t,float>::deviceCalloc(arrSizeList_loc);
+        uint32_t* d_listEntries = DeviceMemory<uint32_t,uint32_t>::deviceCalloc(arrSizeList_loc);
         float* d_x0 = DeviceMemory<uint32_t,float>::deviceCalloc(arrSize_loc);
         float* d_b = DeviceMemory<uint32_t,float>::deviceCalloc(arrSize_loc);
-        DeviceMemory<uint32_t,float>::copyHostToDevice(arrSizeList_loc, listEntries, d_listEntries);
+        DeviceMemory<uint32_t,uint32_t>::copyHostToDevice(arrSizeList_loc, listEntries, d_listEntries);
         DeviceMemory<uint32_t,float>::copyHostToDevice(arrSize_loc, x0, d_x0);
         DeviceMemory<uint32_t,float>::copyHostToDevice(arrSize_loc, b,  d_b);
     #endif

--- a/Tests/ConjugateGradient/unitt_64.cpp
+++ b/Tests/ConjugateGradient/unitt_64.cpp
@@ -52,10 +52,10 @@ int main() {
     }
 
     #ifdef USE_GPU
-        uint32_t* d_listEntries = DeviceMemory<uint32_t,double>::deviceCalloc(arrSizeList_loc);
+        uint32_t* d_listEntries = DeviceMemory<uint32_t,uint32_t>::deviceCalloc(arrSizeList_loc);
         double* d_x0 = DeviceMemory<uint32_t,double>::deviceCalloc(arrSize_loc);
         double* d_b = DeviceMemory<uint32_t,double>::deviceCalloc(arrSize_loc);
-        DeviceMemory<uint32_t,double>::copyHostToDevice(arrSizeList_loc, listEntries, d_listEntries);
+        DeviceMemory<uint32_t,uint32_t>::copyHostToDevice(arrSizeList_loc, listEntries, d_listEntries);
         DeviceMemory<uint32_t,double>::copyHostToDevice(arrSize_loc, x0, d_x0);
         DeviceMemory<uint32_t,double>::copyHostToDevice(arrSize_loc, b,  d_b);
     #endif

--- a/Tests/ConjugateGradient/unitt_64.cpp
+++ b/Tests/ConjugateGradient/unitt_64.cpp
@@ -20,6 +20,7 @@ int main() {
     // Problem definitions
     //uint32_t arrSize = 8*1280000;
     uint32_t arrSize = (uint32_t)(20000000);
+    uint32_t arrSizeList = arrSize;
     uint32_t mIters = 5;
     double tol = 1e-5;
 
@@ -35,6 +36,11 @@ int main() {
         arrSize_loc = arrSize_perRank[client_rank];
     }
 
+    // No periodicity, so listEntries is just a list of 0 to arrSize_loc-1
+    uint32_t arrSizeList_loc = arrSize_loc;
+    uint32_t *listEntries = (uint32_t *)calloc(arrSizeList_loc, sizeof(uint32_t));
+    for (uint32_t i = 0; i < arrSizeList_loc; i++) listEntries[i] = i;
+
     if (world_rank == 0) printf("Running test with %d MPI ranks, array size %d per rank\n", client_size, arrSize_loc);
 
     // Generate data for test
@@ -46,8 +52,10 @@ int main() {
     }
 
     #ifdef USE_GPU
+        uint32_t* d_listEntries = DeviceMemory<uint32_t,double>::deviceCalloc(arrSizeList_loc);
         double* d_x0 = DeviceMemory<uint32_t,double>::deviceCalloc(arrSize_loc);
         double* d_b = DeviceMemory<uint32_t,double>::deviceCalloc(arrSize_loc);
+        DeviceMemory<uint32_t,double>::copyHostToDevice(arrSizeList_loc, listEntries, d_listEntries);
         DeviceMemory<uint32_t,double>::copyHostToDevice(arrSize_loc, x0, d_x0);
         DeviceMemory<uint32_t,double>::copyHostToDevice(arrSize_loc, b,  d_b);
     #endif
@@ -65,13 +73,13 @@ int main() {
     #endif
 
     // Plan the solver
-    ConjugateGradient<uint32_t, double> Solver(client_comm, arrSize_loc, mIters, tol);
+    ConjugateGradient<uint32_t, double> Solver(client_comm, arrSize_loc, arrSizeList_loc, mIters, tol);
 
     // Setup the solver
     #if defined(USE_GPU)
-        Solver.setup(d_x0, d_b);
+        Solver.setup(d_listEntries, d_x0, d_b);
     #else
-        Solver.setup(x0, b);
+        Solver.setup(listEntries, x0, b);
     #endif
 
     // Run the solver

--- a/Tests/FlexiblePCG/unitt_32.cpp
+++ b/Tests/FlexiblePCG/unitt_32.cpp
@@ -28,6 +28,13 @@ int main() {
         globalStart += arrSize_perRank[r];
     }
 
+    // In this case, there are no shared nodes and periodicity is already accounted for, so listEntries is just 0:N_loc-1 for each rank
+    uint32_t Nworking = N_loc;
+    uint32_t* listEntries = (uint32_t *)calloc(N_loc, sizeof(uint32_t));
+    for (uint32_t i = 0; i < N_loc; ++i) {
+        listEntries[i] = i;
+    }
+
     // Generate tridiagonal matrix
     float *cl = (float *)calloc(N_loc, sizeof(float));
     float *dl = (float *)calloc(N_loc, sizeof(float));
@@ -44,12 +51,15 @@ int main() {
 
     #ifdef USE_GPU
         // Generate device vars
+        uint32_t* d_listEntries;
         float *d_cl, *d_dl, *d_el, *d_x0, *d_b;
+        d_listEntries = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
         d_cl = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
         d_dl = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
         d_el = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
         d_x0 = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
         d_b = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
+        DeviceMemory<uint32_t, float>::copyHostToDevice(N_loc, listEntries, d_listEntries);
         DeviceMemory<uint32_t, float>::copyHostToDevice(N_loc, cl, d_cl);
         DeviceMemory<uint32_t, float>::copyHostToDevice(N_loc, dl, d_dl);
         DeviceMemory<uint32_t, float>::copyHostToDevice(N_loc, el, d_el);
@@ -61,11 +71,11 @@ int main() {
     uint32_t maxIters = 200;
     double tol = 1e-7;
     MPI_Comm client_comm = client_commObj.getLibComm();
-    ConjugateGradient<uint32_t, float> solver(client_comm, N_loc, maxIters, tol);
+    ConjugateGradient<uint32_t, float> solver(client_comm, N_loc, Nworking, maxIters, tol);
     #if defined (USE_GPU)
-        solver.setup(d_x0, d_b);
+        solver.setup(d_listEntries, d_x0, d_b);
     #else
-        solver.setup(x0, b);
+        solver.setup(listEntries, x0, b);
     #endif
 
     // If running on GPU, get the kernel stream for use in the matvec

--- a/Tests/FlexiblePCG/unitt_32.cpp
+++ b/Tests/FlexiblePCG/unitt_32.cpp
@@ -53,13 +53,13 @@ int main() {
         // Generate device vars
         uint32_t* d_listEntries;
         float *d_cl, *d_dl, *d_el, *d_x0, *d_b;
-        d_listEntries = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
+        d_listEntries = DeviceMemory<uint32_t, uint32_t>::deviceCalloc(N_loc);
         d_cl = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
         d_dl = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
         d_el = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
         d_x0 = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
         d_b = DeviceMemory<uint32_t, float>::deviceCalloc(N_loc);
-        DeviceMemory<uint32_t, float>::copyHostToDevice(N_loc, listEntries, d_listEntries);
+        DeviceMemory<uint32_t, uint32_t>::copyHostToDevice(N_loc, listEntries, d_listEntries);
         DeviceMemory<uint32_t, float>::copyHostToDevice(N_loc, cl, d_cl);
         DeviceMemory<uint32_t, float>::copyHostToDevice(N_loc, dl, d_dl);
         DeviceMemory<uint32_t, float>::copyHostToDevice(N_loc, el, d_el);

--- a/Tests/FlexiblePCG/unitt_64.cpp
+++ b/Tests/FlexiblePCG/unitt_64.cpp
@@ -28,6 +28,14 @@ int main() {
         globalStart += arrSize_perRank[r];
     }
 
+    // In this case, there are no shared nodes and periodicity is already accounted for, so listEntries is just 0:N_loc-1 for each rank
+    uint32_t Nworking = N_loc;
+    uint32_t *listEntries = (uint32_t *)calloc(N_loc, sizeof(uint32_t));
+    for (uint32_t i = 0; i < N_loc; ++i)
+    {
+        listEntries[i] = i;
+    }
+
     // Generate tridiagonal matrix
     double *cl = (double *)calloc(N_loc, sizeof(double));
     double *dl = (double *)calloc(N_loc, sizeof(double));
@@ -44,12 +52,15 @@ int main() {
 
     #ifdef USE_GPU
         // Generate device vars
+        uint32_t* d_listEntries;
         double *d_cl, *d_dl, *d_el, *d_x0, *d_b;
+        d_listEntries = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
         d_cl = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
         d_dl = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
         d_el = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
         d_x0 = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
         d_b = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
+        DeviceMemory<uint32_t, double>::copyHostToDevice(N_loc, listEntries, d_listEntries);
         DeviceMemory<uint32_t, double>::copyHostToDevice(N_loc, cl, d_cl);
         DeviceMemory<uint32_t, double>::copyHostToDevice(N_loc, dl, d_dl);
         DeviceMemory<uint32_t, double>::copyHostToDevice(N_loc, el, d_el);
@@ -61,11 +72,11 @@ int main() {
     uint32_t maxIters = 200;
     double tol = 1e-7;
     MPI_Comm client_comm = client_commObj.getLibComm();
-    ConjugateGradient<uint32_t, double> solver(client_comm, N_loc, maxIters, tol);
+    ConjugateGradient<uint32_t, double> solver(client_comm, N_loc, Nworking, maxIters, tol);
     #if defined (USE_GPU)
-        solver.setup(d_x0, d_b);
+        solver.setup(d_listEntries, d_x0, d_b);
     #else
-        solver.setup(x0, b);
+        solver.setup(listEntries, x0, b);
     #endif
 
     // If running on GPU, get the kernel stream for use in the matvec

--- a/Tests/FlexiblePCG/unitt_64.cpp
+++ b/Tests/FlexiblePCG/unitt_64.cpp
@@ -54,13 +54,13 @@ int main() {
         // Generate device vars
         uint32_t* d_listEntries;
         double *d_cl, *d_dl, *d_el, *d_x0, *d_b;
-        d_listEntries = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
+        d_listEntries = DeviceMemory<uint32_t, uint32_t>::deviceCalloc(N_loc);
         d_cl = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
         d_dl = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
         d_el = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
         d_x0 = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
         d_b = DeviceMemory<uint32_t, double>::deviceCalloc(N_loc);
-        DeviceMemory<uint32_t, double>::copyHostToDevice(N_loc, listEntries, d_listEntries);
+        DeviceMemory<uint32_t, uint32_t>::copyHostToDevice(N_loc, listEntries, d_listEntries);
         DeviceMemory<uint32_t, double>::copyHostToDevice(N_loc, cl, d_cl);
         DeviceMemory<uint32_t, double>::copyHostToDevice(N_loc, dl, d_dl);
         DeviceMemory<uint32_t, double>::copyHostToDevice(N_loc, el, d_el);

--- a/Tests/IterSolvers/TestSolver.cpp
+++ b/Tests/IterSolvers/TestSolver.cpp
@@ -1,7 +1,7 @@
 #include "TestSolver.hpp"
 
 template <typename ITYPE, typename RTYPE>
-TestSolver<ITYPE, RTYPE>::TestSolver(MPI_Comm &c_comm, ITYPE arrSize, ITYPE maxIters, double tol) : IterSolvers<ITYPE, RTYPE>(c_comm, arrSize, maxIters, tol)
+TestSolver<ITYPE, RTYPE>::TestSolver(MPI_Comm &c_comm, ITYPE arrSize, ITYPE arrSizeList, ITYPE maxIters, double tol) : IterSolvers<ITYPE, RTYPE>(c_comm, arrSize, arrSizeList, maxIters, tol)
 {
     PUSH_RANGE("TestSolver::TestSolver",4);
     if (this->flag_planned == false) {
@@ -28,6 +28,10 @@ void TestSolver<ITYPE, RTYPE>::CheckSetup() {
 
     // Check referenced arrays
     #if defined (USE_GPU)
+        if (this->d_listEntries == nullptr) {
+            std::cerr << "IterSolvers setup failed: d_listEntries is null!" << std::endl;
+            exit(EXIT_FAILURE);
+        }
         if (this->d_x0 == nullptr) {
             std::cerr << "IterSolvers setup failed: d_x0 is null!" << std::endl;
             exit(EXIT_FAILURE);
@@ -37,6 +41,10 @@ void TestSolver<ITYPE, RTYPE>::CheckSetup() {
             exit(EXIT_FAILURE);
         }
     #else
+        if (this->listEntries == nullptr) {
+            std::cerr << "IterSolvers setup failed: listEntries is null!" << std::endl;
+            exit(EXIT_FAILURE);
+        }
         if (this->x0 == nullptr) {
             std::cerr << "IterSolvers setup failed: x0 is null!" << std::endl;
             exit(EXIT_FAILURE);

--- a/Tests/IterSolvers/TestSolver.hpp
+++ b/Tests/IterSolvers/TestSolver.hpp
@@ -11,7 +11,7 @@ class TestSolver : public IterSolvers<ITYPE,RTYPE>
     private:
     public:
         // Constructor
-        TestSolver(MPI_Comm &c_comm, ITYPE arrSize, ITYPE maxIters, double tol);
+        TestSolver(MPI_Comm &c_comm, ITYPE arrSize, ITYPE arrSizeList, ITYPE maxIters, double tol);
 
         // Destructor
         ~TestSolver();

--- a/Tests/IterSolvers/unitt_32.cpp
+++ b/Tests/IterSolvers/unitt_32.cpp
@@ -33,10 +33,10 @@ int main() {
         dim3 kBlock(TILE_SIZE,1,1);
         DeviceUtils::Stream_t kStream;
         DeviceUtils::StreamCreate(&kStream);
-        float* d_listEntries_l = DeviceMemory<uint32_t,float>::deviceCalloc(arrSizeList);
+        uint32_t* d_listEntries_l = DeviceMemory<uint32_t,uint32_t>::deviceCalloc(arrSizeList);
         float* d_inicond_l = DeviceMemory<uint32_t,float>::deviceCalloc(arrSize_l);
         float* d_rhs_l = DeviceMemory<uint32_t,float>::deviceCalloc(arrSize_l);
-        DeviceMemory<uint32_t,float>::copyHostToDevice(arrSizeList, listEntries_l, d_listEntries_l);
+        DeviceMemory<uint32_t,uint32_t>::copyHostToDevice(arrSizeList, listEntries_l, d_listEntries_l);
         DeviceUtils::launchKernel(set_array<uint32_t, float>, kGrid, kBlock, kStream, d_inicond_l, 1.0f, arrSize_l);
         DeviceUtils::launchKernel(set_array<uint32_t, float>, kGrid, kBlock, kStream, d_rhs_l, 3.0f, arrSize_l);
         DeviceUtils::StreamSynchronize(kStream);

--- a/Tests/IterSolvers/unitt_32.cpp
+++ b/Tests/IterSolvers/unitt_32.cpp
@@ -11,11 +11,18 @@ int main() {
 
     // Basic data
     uint32_t arrSize_l = static_cast<uint32_t>(1024000);
+    uint32_t arrSizeList = arrSize_l; // For this test, we can set arrSizeList equal to arrSize_l
     uint32_t maxIters = 10;
     double tol = 1e-6;
 
     // Create an instance of TestSolver
-    TestSolver<uint32_t,float> tSolv(clientComm, arrSize_l, maxIters, tol);
+    TestSolver<uint32_t,float> tSolv(clientComm, arrSize_l, arrSizeList, maxIters, tol);
+
+    // listEntries goes from 0 to arrSizeList-1
+    uint32_t* listEntries_l = (uint32_t*)calloc(arrSizeList, sizeof(uint32_t));
+    for (uint32_t i = 0; i < arrSizeList; ++i) {
+        listEntries_l[i] = i;
+    }
 
     // Setup test
     PUSH_RANGE("Setup Test",5);
@@ -26,12 +33,14 @@ int main() {
         dim3 kBlock(TILE_SIZE,1,1);
         DeviceUtils::Stream_t kStream;
         DeviceUtils::StreamCreate(&kStream);
+        float* d_listEntries_l = DeviceMemory<uint32_t,float>::deviceCalloc(arrSizeList);
         float* d_inicond_l = DeviceMemory<uint32_t,float>::deviceCalloc(arrSize_l);
         float* d_rhs_l = DeviceMemory<uint32_t,float>::deviceCalloc(arrSize_l);
+        DeviceMemory<uint32_t,float>::copyHostToDevice(arrSizeList, listEntries_l, d_listEntries_l);
         DeviceUtils::launchKernel(set_array<uint32_t, float>, kGrid, kBlock, kStream, d_inicond_l, 1.0f, arrSize_l);
         DeviceUtils::launchKernel(set_array<uint32_t, float>, kGrid, kBlock, kStream, d_rhs_l, 3.0f, arrSize_l);
         DeviceUtils::StreamSynchronize(kStream);
-        tSolv.setup(d_inicond_l, d_rhs_l);
+        tSolv.setup(d_listEntries_l, d_inicond_l, d_rhs_l);
     #else
         float* inicond_l = (float*)calloc(arrSize_l, sizeof(float));
         float* rhs_l = (float*)calloc(arrSize_l, sizeof(float));
@@ -39,7 +48,7 @@ int main() {
             inicond_l[i] = 1.0f;
             rhs_l[i] = 3.0f;
         }
-        tSolv.setup(inicond_l, rhs_l);
+        tSolv.setup(listEntries_l, inicond_l, rhs_l);
     #endif
     tSolv.CheckSetup();
     POP_RANGE();

--- a/Tests/IterSolvers/unitt_64.cpp
+++ b/Tests/IterSolvers/unitt_64.cpp
@@ -33,14 +33,14 @@ int main() {
         dim3 kBlock(TILE_SIZE,1,1);
         DeviceUtils::Stream_t kStream;
         DeviceUtils::StreamCreate(&kStream);
-        uint32_t* d_listEntries_l = DeviceMemory<uint32_t,double>::deviceCalloc(arrSizeList);
+        uint32_t* d_listEntries_l = DeviceMemory<uint32_t,uint32_t>::deviceCalloc(arrSizeList);
         double* d_inicond_l = DeviceMemory<uint32_t,double>::deviceCalloc(arrSize_l);
         double* d_rhs_l = DeviceMemory<uint32_t,double>::deviceCalloc(arrSize_l);
-        DeviceMemory<uint32_t,double>::copyHostToDevice(arrSizeList, listEntries_l, d_listEntries_l);
+        DeviceMemory<uint32_t,uint32_t>::copyHostToDevice(arrSizeList, listEntries_l, d_listEntries_l);
         DeviceUtils::launchKernel(set_array<uint32_t, double>, kGrid, kBlock, kStream, d_inicond_l, 1.0, arrSize_l);
         DeviceUtils::launchKernel(set_array<uint32_t, double>, kGrid, kBlock, kStream, d_rhs_l, 3.0, arrSize_l);
         DeviceUtils::StreamSynchronize(kStream);
-        tSolv.setup(d_inicond_l, d_rhs_l);
+        tSolv.setup(d_listEntries_l, d_inicond_l, d_rhs_l);
     #else
         double* inicond_l = (double*)calloc(arrSize_l, sizeof(double));
         double* rhs_l = (double*)calloc(arrSize_l, sizeof(double));

--- a/Tests/IterSolvers/unitt_64.cpp
+++ b/Tests/IterSolvers/unitt_64.cpp
@@ -11,11 +11,18 @@ int main() {
 
     // Basic data
     uint32_t arrSize_l = static_cast<uint32_t>(1024000);
+    uint32_t arrSizeList = arrSize_l; // For this test, we can set arrSizeList equal to arrSize_l
     uint32_t maxIters = 10;
     double tol = 1e-6;
 
     // Create an instance of TestSolver
-    TestSolver<uint32_t,double> tSolv(clientComm, arrSize_l, maxIters, tol);
+    TestSolver<uint32_t,double> tSolv(clientComm, arrSize_l, arrSizeList, maxIters, tol);
+
+    // listEntries goes from 0 to arrSizeList-1
+    uint32_t* listEntries_l = (uint32_t*)calloc(arrSizeList, sizeof(uint32_t));
+    for (uint32_t i = 0; i < arrSizeList; ++i) {
+        listEntries_l[i] = i;
+    }
 
     // Setup test
     PUSH_RANGE("Setup Test",5);
@@ -26,8 +33,10 @@ int main() {
         dim3 kBlock(TILE_SIZE,1,1);
         DeviceUtils::Stream_t kStream;
         DeviceUtils::StreamCreate(&kStream);
+        uint32_t* d_listEntries_l = DeviceMemory<uint32_t,double>::deviceCalloc(arrSizeList);
         double* d_inicond_l = DeviceMemory<uint32_t,double>::deviceCalloc(arrSize_l);
         double* d_rhs_l = DeviceMemory<uint32_t,double>::deviceCalloc(arrSize_l);
+        DeviceMemory<uint32_t,double>::copyHostToDevice(arrSizeList, listEntries_l, d_listEntries_l);
         DeviceUtils::launchKernel(set_array<uint32_t, double>, kGrid, kBlock, kStream, d_inicond_l, 1.0, arrSize_l);
         DeviceUtils::launchKernel(set_array<uint32_t, double>, kGrid, kBlock, kStream, d_rhs_l, 3.0, arrSize_l);
         DeviceUtils::StreamSynchronize(kStream);
@@ -39,7 +48,7 @@ int main() {
             inicond_l[i] = 1.0;
             rhs_l[i] = 3.0;
         }
-        tSolv.setup(inicond_l, rhs_l);
+        tSolv.setup(listEntries_l, inicond_l, rhs_l);
     #endif
     tSolv.CheckSetup();
     POP_RANGE();

--- a/Tests/LinAlgebra_CG_F90/unitt_32.F90
+++ b/Tests/LinAlgebra_CG_F90/unitt_32.F90
@@ -204,14 +204,15 @@ program test_32
    real(c_float)     , parameter :: pi = 3.14159265358979323846_c_float
 
    ! Internal vars
-   integer(c_int32_t)         :: nWorking, i, j, k
-   real(c_float)              :: err, max_err
-   real(c_float), allocatable :: gridPts(:), x0(:), rhs(:), x_solve(:), Axsolve(:), x_exact(:)
-   type(FDM1D_t), target      :: laplObj
-   type(c_ptr)                :: glassSolver
-   type(c_ptr)                :: opData
-   type(c_funptr)             :: matvecFunc
-   type(c_funptr)             :: precondFunc
+   integer(c_int32_t)              :: nWorking, i, j, k, nListEntries
+   integer(c_int32_t), allocatable :: listEntries(:)
+   real(c_float)                   :: err, max_err
+   real(c_float), allocatable      :: gridPts(:), x0(:), rhs(:), x_solve(:), Axsolve(:), x_exact(:)
+   type(FDM1D_t), target           :: laplObj
+   type(c_ptr)                     :: glassSolver
+   type(c_ptr)                     :: opData
+   type(c_funptr)                  :: matvecFunc
+   type(c_funptr)                  :: precondFunc
 
    ! Initialize MPI
    call MPI_Init(ierr)
@@ -231,6 +232,14 @@ program test_32
 
    ! Working nodes is the number of nodes minus 1
    nWorking = nNodes - 1
+   nListEntries = nWorking
+   allocate(listEntries(nListEntries))
+   !$acc enter data create(listEntries)
+   !$acc parallel loop present(listEntries)
+   do i = 1, nListEntries
+      listEntries(i) = i-1
+   end do
+   !$acc end parallel loop
 
    ! Set object info
    laplObj%ndof         = nWorking
@@ -267,11 +276,11 @@ program test_32
    !$acc update device(x0, rhs, x_exact, laplObj%sigma)
 
    ! Create the GLASs solver
-   glassSolver = cg_create_u32_pf(client_comm, nWorking, maxIters, tol)
+   glassSolver = cg_create_u32_pf(client_comm, nWorking, nListEntries, maxIters, tol)
 
    ! Setup x0 and b
-   !$acc host_data use_device(x0, rhs)
-   call cg_setup_u32_f(glassSolver, x0, rhs)
+   !$acc host_data use_device(listEntries, x0, rhs)
+   call cg_setup_u32_f(glassSolver, listEntries, x0, rhs)
    !$acc end host_data
 
    ! Setup the matvec and preconditioner

--- a/src/Libs/Kernels_Lv1/includes/Kernels_Lv1.cuh
+++ b/src/Libs/Kernels_Lv1/includes/Kernels_Lv1.cuh
@@ -84,6 +84,39 @@
     }
 
     template <typename ITYPE, typename RTYPE>
+    __global__ void guided_dot_product(const RTYPE* a, const RTYPE* b, double* r, const ITYPE Nworking, const ITYPE* listWorking) {
+        // Indexes
+        ITYPE gid = blockIdx.x * blockDim.x + threadIdx.x;
+        ITYPE tid = threadIdx.x;
+
+        // Partials
+        __shared__ float cache[TILE_SIZE];
+        double value = 0.0;
+        while (gid < Nworking) {
+            ITYPE idx = listWorking[gid];
+            value += static_cast<double>(a[idx] * b[idx]);
+            gid += blockDim.x * gridDim.x;
+        }
+        cache[tid] = value;
+        __syncthreads();
+
+        // Reduction in shared memory
+        ITYPE i = blockDim.x / 2;
+        while (i != 0) {
+            if (tid < i) {
+                cache[tid] += cache[tid + i];
+            }
+            __syncthreads();
+            i /= 2;
+        }
+
+        // Atomic add to global result
+        if (tid == 0) {
+            atomicAdd(r, cache[0]);
+        }
+    }
+
+    template <typename ITYPE, typename RTYPE>
     __global__ void scale(const RTYPE a, RTYPE* x, ITYPE N) {
         ITYPE gid = blockIdx.x * blockDim.x + threadIdx.x;
         while (gid < N) {
@@ -147,6 +180,8 @@
     __global__ void axpy(const RTYPE a, const RTYPE* x, RTYPE* y, const ITYPE N);
     template <typename ITYPE, typename RTYPE>
     __global__ void dot_product(const RTYPE* a, const RTYPE* b, double* r, ITYPE N);
+    template <typename ITYPE, typename RTYPE>
+    __global__ void guided_dot_product(const RTYPE* a, const RTYPE* b, double* r, const ITYPE Nworking, const ITYPE* listWorking);
     template <typename ITYPE, typename RTYPE>
     __global__ void scale(const RTYPE a, RTYPE* x, ITYPE N);
     template <typename ITYPE, typename RTYPE>

--- a/src/Libs/Kernels_Lv1/sources/Kernels_Lv1.cu
+++ b/src/Libs/Kernels_Lv1/sources/Kernels_Lv1.cu
@@ -55,6 +55,39 @@
     }
 
     template <typename ITYPE, typename RTYPE>
+    __global__ void dot_product(const RTYPE* a, const RTYPE* b, double* r, const ITYPE Nworking, const ITYPE* listWorking) {
+        // Indexes
+        ITYPE gid = blockIdx.x * blockDim.x + threadIdx.x;
+        ITYPE tid = threadIdx.x;
+
+        // Partials
+        __shared__ float cache[TILE_SIZE];
+        double value = 0.0;
+        while (gid < Nworking) {
+            ITYPE idx = listWorking[gid];
+            value += static_cast<double>(a[idx] * b[idx]);
+            gid += blockDim.x * gridDim.x;
+        }
+        cache[tid] = value;
+        __syncthreads();
+
+        // Reduction in shared memory
+        ITYPE i = blockDim.x / 2;
+        while (i != 0) {
+            if (tid < i) {
+                cache[tid] += cache[tid + i];
+            }
+            __syncthreads();
+            i /= 2;
+        }
+
+        // Atomic add to global result
+        if (tid == 0) {
+            atomicAdd(r, cache[0]);
+        }
+    }
+
+    template <typename ITYPE, typename RTYPE>
     __global__ void scale(const RTYPE a, RTYPE* x, ITYPE N) {
         ITYPE gid = blockIdx.x * blockDim.x + threadIdx.x;
         while (gid < N) {
@@ -127,6 +160,12 @@ template __global__ void dot_product<uint64_t, double>(const double*, const doub
 template __global__ void dot_product<uint32_t, DeviceUtils::bf16>(const DeviceUtils::bf16*, const DeviceUtils::bf16*, double*, uint32_t);
 template __global__ void dot_product<uint64_t, DeviceUtils::bf16>(const DeviceUtils::bf16*, const DeviceUtils::bf16*, double*, uint64_t);
 
+template __global__ void guided_dot_product<uint32_t, float>(const float*, const float*, double*, const uint32_t, const uint32_t*);
+template __global__ void guided_dot_product<uint64_t, float>(const float*, const float*, double*, const uint64_t, const uint64_t*);
+template __global__ void guided_dot_product<uint32_t, double>(const double*, const double*, double*, const uint32_t, const uint32_t*);
+template __global__ void guided_dot_product<uint64_t, double>(const double*, const double*, double*, const uint64_t, const uint64_t*);
+template __global__ void guided_dot_product<uint32_t, DeviceUtils::bf16>(const DeviceUtils::bf16*, const DeviceUtils::bf16*, double*, const uint32_t, const uint32_t*);
+template __global__ void guided_dot_product<uint64_t, DeviceUtils::bf16>(const DeviceUtils::bf16*, const DeviceUtils::bf16*, double*, const uint64_t, const uint64_t*);
 
 template __global__ void scale<uint32_t, float>(const float, float*, uint32_t);
 template __global__ void scale<uint64_t, float>(const float, float*, uint64_t);

--- a/src/Libs/LinAlgebra/IterSolvers/includes/ConjugateGradient.hpp
+++ b/src/Libs/LinAlgebra/IterSolvers/includes/ConjugateGradient.hpp
@@ -33,7 +33,7 @@ class ConjugateGradient : public IterSolvers<ITYPE, RTYPE>
         ConjugateGradient();
 
         // Param constructor with MPI_Comm
-        ConjugateGradient(MPI_Comm& c_comm, ITYPE arrSize, ITYPE maxIters, double tol);
+        ConjugateGradient(MPI_Comm& c_comm, ITYPE arrSize, ITYPE arrSizeList, ITYPE maxIters, double tol);
 
         // Destructor, calls parent destructor
         ~ConjugateGradient();

--- a/src/Libs/LinAlgebra/IterSolvers/includes/ConjugateGradient_wrapper.hpp
+++ b/src/Libs/LinAlgebra/IterSolvers/includes/ConjugateGradient_wrapper.hpp
@@ -18,15 +18,15 @@ extern "C" {
     typedef void (*halocomm_f64)(double *x_inout, void *user_data);
 
     // ---- uint32_t / float ----
-    void *cg_create_u32_pf(int fcomm, uint32_t arrSize, uint32_t maxIters, double tol); // Parallel version
+    void *cg_create_u32_pf(int fcomm, uint32_t arrSize, uint32_t arrSizeList, uint32_t maxIters, double tol); // Parallel version
     void cg_destroy_u32_f(void *solver);
-    void cg_setup_u32_f(void *solver, const float* inicond, const float* rhs);
+    void cg_setup_u32_f(void *solver, const uint32_t *listEntries, const float* inicond, const float* rhs);
     void cg_solve_u32_f(void *solver, matvec_f32 matvec, void *user_data);
     void fpcg_solve_u32_f(void *solver, matvec_f32 matvec, precond_f32 precond, void *user_data);
     void cg_get_solution_u32_f(void *solver, float* sol);
 
     // ---- uint32_t / double ----
-    void *cg_create_u32_pd(int fcomm, uint32_t arrSize, uint32_t maxIters, double tol); // Parallel version
+    void *cg_create_u32_pd(int fcomm, uint32_t arrSize, uint32_t arrSizeList, uint32_t maxIters, double tol); // Parallel version
     void cg_destroy_u32_d(void *solver);
     void cg_setup_u32_d(void *solver, const double* inicond, const double* rhs);
     void cg_solve_u32_d(void *solver, matvec_f64 matvec, void *user_data);

--- a/src/Libs/LinAlgebra/IterSolvers/includes/IterSolvers.hpp
+++ b/src/Libs/LinAlgebra/IterSolvers/includes/IterSolvers.hpp
@@ -21,6 +21,7 @@ class IterSolvers : public EntryPoint<ITYPE, RTYPE>
         bool flag_planned = false;
         bool flag_setup = false;
         ITYPE arrSize;
+        ITYPE arrSizeList;
         const ITYPE auxSize = 1;
         ITYPE maxIters;
         ITYPE iter;
@@ -28,18 +29,19 @@ class IterSolvers : public EntryPoint<ITYPE, RTYPE>
 
         // Vectors for the linear solver
         //     Host,    Device
-        double *tmpDot, *d_tmpDot; // Auxiliaries for performing allreduces
-        double *mpiTmp, *d_mpiTmp; // Auxiliary single entry array for MPI_Allreduce
-        double *res0,   *d_res0;   // Initial residual
-        double *resk,   *d_resk;   // Initial residual
-        double *aux,    *d_aux;    // Auxiliary single entry array
-        RTYPE  *x_sol,  *d_x_sol;  // Solution
-        RTYPE  *x0,     *d_x0;     // Initial guess
-        RTYPE  *b,      *d_b;      // RHS
-        RTYPE  *r0,     *d_r0;     // Initial residual
-        RTYPE  *rk,     *d_rk;     // Residual
-        RTYPE  *zk,     *d_zk;     // Preconditioned residual
-        RTYPE  *Ax,     *d_Ax;     // Matrix-vector product
+        double *tmpDot,      *d_tmpDot;      // Auxiliaries for performing allreduces
+        double *mpiTmp,      *d_mpiTmp;      // Auxiliary single entry array for MPI_Allreduce
+        double *res0,        *d_res0;        // Initial residual
+        double *resk,        *d_resk;        // Initial residual
+        double *aux,         *d_aux;         // Auxiliary single entry array
+        RTYPE  *x_sol,       *d_x_sol;       // Solution
+        RTYPE  *x0,          *d_x0;          // Initial guess
+        RTYPE  *b,           *d_b;           // RHS
+        RTYPE  *r0,          *d_r0;          // Initial residual
+        RTYPE  *rk,          *d_rk;          // Residual
+        RTYPE  *zk,          *d_zk;          // Preconditioned residual
+        RTYPE  *Ax,          *d_Ax;          // Matrix-vector product
+        ITYPE  *listEntries, *d_listEntries; // List of entries for guided dot product
 
         // Comm_Utils object (alias to inherited entrypoint_comm)
         Comm_Utils& IterSolvers_comm = this->entrypoint_comm;
@@ -58,16 +60,16 @@ class IterSolvers : public EntryPoint<ITYPE, RTYPE>
         IterSolvers();
 
         // Param constructor with Comm_Utils obj
-        IterSolvers(MPI_Comm& c_comm, ITYPE arrSize, ITYPE maxIters, double tol);
+        IterSolvers(MPI_Comm& c_comm, ITYPE arrSize, ITYPE arrSizeList, ITYPE maxIters, double tol);
 
         // Destructor
         ~IterSolvers();
 
         // Solver plan
-        void plan(ITYPE arrSize, ITYPE maxIters, double tol);
+        void plan(ITYPE arrSize, ITYPE arrSizeList, ITYPE maxIters, double tol);
 
         // Solver setup
-        void setup(RTYPE* inicond, RTYPE* rhs);
+        void setup(ITYPE* listEntries, RTYPE* inicond, RTYPE* rhs);
 
         // Get the solution back
         void getSolution(RTYPE* clientPtr);

--- a/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient.cpp
+++ b/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient.cpp
@@ -23,7 +23,7 @@ ConjugateGradient<ITYPE, RTYPE>::ConjugateGradient() : IterSolvers<ITYPE, RTYPE>
 
 template <typename ITYPE, typename RTYPE>
 // constructor with parameters and communicator
-ConjugateGradient<ITYPE, RTYPE>::ConjugateGradient(MPI_Comm& c_comm, ITYPE arrSize, ITYPE maxIters, double tol) : IterSolvers<ITYPE, RTYPE>(c_comm, arrSize, maxIters, tol) {
+ConjugateGradient<ITYPE, RTYPE>::ConjugateGradient(MPI_Comm& c_comm, ITYPE arrSize, ITYPE arrSizeList, ITYPE maxIters, double tol) : IterSolvers<ITYPE, RTYPE>(c_comm, arrSize, arrSizeList, maxIters, tol) {
     if (this->IterSolvers_comm.getWorldRank() == 0) std::cout << "--| IterSolvers: using PCG solver!" << std::endl;
     PUSH_RANGE("ConjugateGradient::Constructor(param+comm)", 4);
     // Allocate host memory using calloc (ensures init to 0)

--- a/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient.cpp
+++ b/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient.cpp
@@ -260,7 +260,7 @@ void ConjugateGradient<ITYPE, RTYPE>::cgSolver(const MatVecOp& matvec) {
 
             // resk = dot(r0,r0) - partial, then Allreduce to get full resk
             this->resk[0] = zero_fp64;
-            TensorUtils<ITYPE, RTYPE>::dot_product(this->arrSize, this->rk, this->rk, &this->resk[0]); // resk = rk . rk (partial)
+            TensorUtils<ITYPE, RTYPE>::guided_dot_product(this->arrSizeList, this->listEntries, this->rk, this->rk, &this->resk[0]); // resk = rk . rk (partial)
             if (this->IterSolvers_comm.getLibSize() > 1)
             {
                 this->IterSolvers_comm.Allreduce_Sum(this->resk, this->mpiTmp, 1);
@@ -280,7 +280,7 @@ void ConjugateGradient<ITYPE, RTYPE>::cgSolver(const MatVecOp& matvec) {
 
                 // 2. Compute alpha = (rk.rk) / (pk.Apk) 
                 this->alpha[0] = zero_fp64;
-                TensorUtils<ITYPE, RTYPE>::dot_product(this->arrSize, this->p0, this->Ax, this->alpha); // alpha = pk.Apk (partial)
+                TensorUtils<ITYPE, RTYPE>::guided_dot_product(this->arrSizeList, this->listEntries, this->p0, this->Ax, this->alpha); // alpha = pk.Apk (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     this->IterSolvers_comm.Allreduce_Sum(this->alpha, this->mpiTmp, 1);
@@ -296,7 +296,7 @@ void ConjugateGradient<ITYPE, RTYPE>::cgSolver(const MatVecOp& matvec) {
 
                 // 5. Compute new resk = dot(rk,rk) - partial, then Allreduce to get full resk
                 this->beta[0] = zero_fp64;
-                TensorUtils<ITYPE, RTYPE>::dot_product(this->arrSize, this->rk, this->rk, this->beta); // beta = rk . rk (partial)
+                TensorUtils<ITYPE, RTYPE>::guided_dot_product(this->arrSizeList, this->listEntries, this->rk, this->rk, this->beta); // beta = rk . rk (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     this->IterSolvers_comm.Allreduce_Sum(this->beta, this->mpiTmp, 1);
@@ -551,7 +551,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
 
                 // resk = dot(r0,r0) - partial, then Allreduce to get full resk
                 this->resk[0] = zero_fp64;
-                TensorUtils<ITYPE, RTYPE>::dot_product(this->arrSize, this->rk, this->rk, this->resk); // resk = rk . rk (partial)
+                TensorUtils<ITYPE, RTYPE>::guided_dot_product(this->arrSizeList, this->listEntries, this->rk, this->rk, this->resk); // resk = rk . rk (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     this->mpiTmp[0] = zero_fp64;
@@ -564,7 +564,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
 
                 // Preconditioned residual rk.zk
                 this->resk[0] = zero_fp64;
-                TensorUtils<ITYPE, RTYPE>::dot_product(this->arrSize, this->rk, this->zk, this->resk); // resk = rk.zk (partial)
+                TensorUtils<ITYPE, RTYPE>::guided_dot_product(this->arrSizeList, this->listEntries, this->rk, this->zk, this->resk); // resk = rk.zk (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     this->mpiTmp[0] = zero_fp64;
@@ -584,7 +584,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
 
                 // Compute alpha = (rk.zk) / (pk.Apk)
                 this->alpha[0] = zero_fp64;
-                TensorUtils<ITYPE, RTYPE>::dot_product(this->arrSize, this->p0, this->Ax, this->alpha); // alpha = pk.Apk (partial)
+                TensorUtils<ITYPE, RTYPE>::guided_dot_product(this->arrSizeList, this->listEntries, this->p0, this->Ax, this->alpha); // alpha = pk.Apk (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     this->mpiTmp[0] = zero_fp64;
@@ -601,7 +601,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
 
                 // Compute the new residual norm resk = |rk|
                 this->beta[0] = zero_fp64;
-                TensorUtils<ITYPE, RTYPE>::dot_product(this->arrSize, this->rk, this->rk, this->beta); // beta = rk+1 . rk+1 (partial)
+                TensorUtils<ITYPE, RTYPE>::guided_dot_product(this->arrSizeList, this->listEntries, this->rk, this->rk, this->beta); // beta = rk+1 . rk+1 (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     this->mpiTmp[0] = zero_fp64;
@@ -620,7 +620,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
                 // Flexible beta: beta = (rk+1.zk+1 - rk.zk) / (rk.zk) = (resk+1 - aux) / resk
                 // Compute aux = rk+1.zk
                 this->aux[0] = zero_fp64;
-                TensorUtils<ITYPE, RTYPE>::dot_product(this->arrSize, this->rk, this->zk, this->aux); // aux = rk+1.zk (partial)
+                TensorUtils<ITYPE, RTYPE>::guided_dot_product(this->arrSizeList, this->listEntries, this->rk, this->zk, this->aux); // aux = rk+1.zk (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     this->mpiTmp[0] = zero_fp64;
@@ -633,7 +633,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
 
                 // Compute beta = (rk+1.zk+1)
                 this->beta[0] = zero_fp64;
-                TensorUtils<ITYPE, RTYPE>::dot_product(this->arrSize, this->rk, this->zk, this->beta); // beta = rk+1.zk+1 (partial)
+                TensorUtils<ITYPE, RTYPE>::guided_dot_product(this->arrSizeList, this->listEntries, this->rk, this->zk, this->beta); // beta = rk+1.zk+1 (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     this->mpiTmp[0] = zero_fp64;

--- a/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient.cpp
+++ b/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient.cpp
@@ -132,7 +132,7 @@ void ConjugateGradient<ITYPE, RTYPE>::cgSolver(const MatVecOp& matvec) {
                 // Initial residual norm res0 = |r0|
                 PUSH_RANGE("cgSolver: res0 = |r0|", 6);
                 DeviceUtils::launchKernel(set_array<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, this->d_resk, zero_fp64, this->auxSize);
-                DeviceUtils::launchKernel(dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_rk, this->d_resk, this->arrSize); // resk = rk . rk (partial)
+                DeviceUtils::launchKernel(guided_dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_rk, this->d_resk, this->arrSizeList, this->d_listEntries); // resk = rk . rk (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     PUSH_RANGE("cgSolver: comms", 7);
@@ -167,7 +167,7 @@ void ConjugateGradient<ITYPE, RTYPE>::cgSolver(const MatVecOp& matvec) {
                     // Compute alpha = (rk.rk) / (pk.Apk)
                     PUSH_RANGE("cgSolver: alpha", 7);
                     DeviceUtils::launchKernel(set_array<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, this->d_alpha, zero_fp64, this->auxSize);
-                    DeviceUtils::launchKernel(dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_p0, this->d_Ax, this->d_alpha, this->arrSize); // alpha = pk.Apk (partial)
+                    DeviceUtils::launchKernel(guided_dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_p0, this->d_Ax, this->d_alpha, this->arrSizeList, this->d_listEntries); // alpha = pk.Apk (partial)
                     if (this->IterSolvers_comm.getLibSize() > 1)
                     {
                         PUSH_RANGE("cgSolver: comms", 8);
@@ -196,7 +196,7 @@ void ConjugateGradient<ITYPE, RTYPE>::cgSolver(const MatVecOp& matvec) {
                     // Compute the new residual norm resk = |rk|
                     PUSH_RANGE("cgSolver: resk = |rk|", 7);
                     DeviceUtils::launchKernel(set_array<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, this->d_beta, zero_fp64, this->auxSize);
-                    DeviceUtils::launchKernel(dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_rk, this->d_beta, this->arrSize); // beta = rk+1 . rk+1 (partial)
+                    DeviceUtils::launchKernel(guided_dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_rk, this->d_beta, this->arrSizeList, this->d_listEntries); // beta = rk+1 . rk+1 (partial)
                     if (this->IterSolvers_comm.getLibSize() > 1)
                     {
                         PUSH_RANGE("cgSolver: comms", 8);
@@ -228,7 +228,7 @@ void ConjugateGradient<ITYPE, RTYPE>::cgSolver(const MatVecOp& matvec) {
                     // Update pk+1 = rk+1 + beta*pk
                     PUSH_RANGE("cgSolver: update pk", 7);
                     DeviceMemory<ITYPE, double>::copyDeviceToHost(this->auxSize, this->d_beta, this->beta);                                                                  // copy beta to host for axpy
-                    DeviceUtils::launchKernel(scale<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, (RTYPE)this->beta[0], this->d_p0, this->auxSize);     // p0 = beta*p0
+                    DeviceUtils::launchKernel(scale<ITYPE, double>, this->kernelGrid, this->kernelBlock, this->kernelStream, (RTYPE)this->beta[0], this->d_p0, this->arrSize);     // p0 = beta*p0
                     DeviceUtils::launchKernel(axpy<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, (RTYPE)1, this->d_rk, this->d_p0, this->arrSize); // p0 += rk
                     POP_RANGE(); // 7
 
@@ -376,7 +376,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
                 PUSH_RANGE("residual", 6);
                 // resk = dot(rk,rk)
                 DeviceUtils::launchKernel(set_array<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, this->d_resk, zero_fp64, this->auxSize);
-                DeviceUtils::launchKernel(dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_rk, this->d_resk, this->arrSize); // resk = rk . rk (partial)
+                DeviceUtils::launchKernel(guided_dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_rk, this->d_resk, this->arrSizeList, this->d_listEntries); // resk = rk . rk (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     PUSH_RANGE("fpcg comms", 7);
@@ -394,7 +394,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
                 // Precond residual
                 PUSH_RANGE("precond residual", 6);
                 DeviceUtils::launchKernel(set_array<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, this->d_resk, zero_fp64, this->auxSize);
-                DeviceUtils::launchKernel(dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_zk, this->d_resk, this->arrSize); // resk = rk.zk
+                DeviceUtils::launchKernel(guided_dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_zk, this->d_resk, this->arrSizeList, this->d_listEntries); // resk = rk.zk
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     PUSH_RANGE("fpcg comms", 7);
@@ -424,7 +424,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
                 // Compute alpha = (rk.zk) / (pk.Apk)
                 PUSH_RANGE("alpha", 7);
                 DeviceUtils::launchKernel(set_array<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, this->d_alpha, zero_fp64, this->auxSize);
-                DeviceUtils::launchKernel(dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_p0, this->d_Ax, this->d_alpha, this->arrSize); // alpha = pk.Apk (partial)
+                DeviceUtils::launchKernel(guided_dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_p0, this->d_Ax, this->d_alpha, this->arrSizeList, this->d_listEntries); // alpha = pk.Apk (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     PUSH_RANGE("fpcg comms", 8);
@@ -452,7 +452,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
                 // Compute the new residual norm resk = |rk|
                 PUSH_RANGE("resk = |rk|", 7);
                 DeviceUtils::launchKernel(set_array<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, this->d_beta, zero_fp64, this->auxSize);
-                DeviceUtils::launchKernel(dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_rk, this->d_beta, this->arrSize); // beta = rk+1 . rk+1 (partial)
+                DeviceUtils::launchKernel(guided_dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_rk, this->d_beta, this->arrSizeList, this->d_listEntries); // beta = rk+1 . rk+1 (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     PUSH_RANGE("fpcg comms", 8);
@@ -477,7 +477,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
                 // Compute aux = rk+1.zk
                 PUSH_RANGE("rk+1,zk", 7);
                 DeviceUtils::launchKernel(set_array<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, this->d_aux, zero_fp64, this->auxSize);
-                DeviceUtils::launchKernel(dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_zk, this->d_aux, this->arrSize); // aux = rk+1.zk
+                DeviceUtils::launchKernel(guided_dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_zk, this->d_aux, this->arrSizeList, this->d_listEntries); // aux = rk+1.zk
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     PUSH_RANGE("fpcg comms", 8);
@@ -496,7 +496,7 @@ void ConjugateGradient<ITYPE, RTYPE>::fpcgSolver(const MatVecOp& matvec, const P
                 // Compute beta = (rk+1.zk+1)
                 PUSH_RANGE("rk+1,zk+1", 7);
                 DeviceUtils::launchKernel(set_array<ITYPE, double>, this->auxGrid, this->auxBlock, this->kernelStream, this->d_beta, zero_fp64, this->auxSize);
-                DeviceUtils::launchKernel(dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_zk, this->d_beta, this->arrSize); // beta = rk+1.zk+1 (partial)
+                DeviceUtils::launchKernel(guided_dot_product<ITYPE, RTYPE>, this->kernelGrid, this->kernelBlock, this->kernelStream, this->d_rk, this->d_zk, this->d_beta, this->arrSizeList, this->d_listEntries); // beta = rk+1.zk+1 (partial)
                 if (this->IterSolvers_comm.getLibSize() > 1)
                 {
                     PUSH_RANGE("fpcg comms", 8);

--- a/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient_F_wrapper.F90
+++ b/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient_F_wrapper.F90
@@ -5,11 +5,12 @@ module cg_wrapper_mod
         !! ---- uint32_t / float ----
 
         ! Parallel constructor call
-        function cg_create_u32_pf(comm, arrSize, maxIters, tol) bind(C, name="cg_create_u32_pf")
+        function cg_create_u32_pf(comm, arrSize, arrSizeList, maxIters, tol) bind(C, name="cg_create_u32_pf")
             import :: c_ptr, c_int32_t, c_double
             implicit none
             integer(c_int32_t), value :: comm
             integer(c_int32_t), value :: arrSize
+            integer(c_int32_t), value :: arrSizeList
             integer(c_int32_t), value :: maxIters
             real(c_double), value :: tol
             type(c_ptr) :: cg_create_u32_pf
@@ -23,16 +24,18 @@ module cg_wrapper_mod
         end subroutine cg_destroy_u32_f
 
         ! Setup
-        subroutine cg_setup_u32_f(solver, inicond, rhs) bind(C, name="cg_setup_u32_f")
-            import :: c_ptr, c_float
+        subroutine cg_setup_u32_f(solver, listEntries, inicond, rhs) bind(C, name="cg_setup_u32_f")
+            import :: c_ptr, c_float, c_int32_t
             implicit none
             type(c_ptr), value :: solver
 #ifdef USE_CUDA
-            real(c_float), device, intent(in) :: inicond(*)
-            real(c_float), device, intent(in) :: rhs(*)
+            integer(c_int32_t), device, intent(in) :: listEntries(*)
+            real(c_float)     , device, intent(in) :: inicond(*)
+            real(c_float)     , device, intent(in) :: rhs(*)
 #else
-            real(c_float), intent(in) :: inicond(*)
-            real(c_float), intent(in) :: rhs(*)
+            integer(c_int32_t), intent(in) :: listEntries(*)
+            real(c_float)     , intent(in) :: inicond(*)
+            real(c_float)     , intent(in) :: rhs(*)
 #endif
         end subroutine cg_setup_u32_f
 
@@ -70,11 +73,12 @@ module cg_wrapper_mod
         !! ---- uint32_t / double ----
 
         ! Parallel constructor call
-        function cg_create_u32_pd(comm, arrSize, maxIters, tol) bind(C, name="cg_create_u32_pd")
+        function cg_create_u32_pd(comm, arrSize, arrSizeList, maxIters, tol) bind(C, name="cg_create_u32_pd")
             import :: c_ptr, c_int32_t, c_double
             implicit none
             integer(c_int32_t), value :: comm
             integer(c_int32_t), value :: arrSize
+            integer(c_int32_t), value :: arrSizeList
             integer(c_int32_t), value :: maxIters
             real(c_double), value :: tol
             type(c_ptr) :: cg_create_u32_pd
@@ -88,14 +92,16 @@ module cg_wrapper_mod
         end subroutine cg_destroy_u32_d
 
         ! Setup
-        subroutine cg_setup_u32_d(solver, inicond, rhs) bind(C, name="cg_setup_u32_d")
-            import :: c_ptr, c_double
+        subroutine cg_setup_u32_d(solver, listEntries, inicond, rhs) bind(C, name="cg_setup_u32_d")
+            import :: c_ptr, c_double, c_int32_t
             implicit none
             type(c_ptr), value :: solver
 #ifdef USE_CUDA
-            real(c_double), device, intent(in) :: inicond(*)
-            real(c_double), device, intent(in) :: rhs(*)
+            integer(c_int32_t), device, intent(in) :: listEntries(*)
+            real(c_double)    , device, intent(in) :: inicond(*)
+            real(c_double)    , device, intent(in) :: rhs(*)
 #else
+            integer(c_int32_t), intent(in) :: listEntries(*)
             real(c_double), intent(in) :: inicond(*)
             real(c_double), intent(in) :: rhs(*)
 #endif

--- a/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient_wrapper.cpp
+++ b/src/Libs/LinAlgebra/IterSolvers/sources/ConjugateGradient_wrapper.cpp
@@ -8,10 +8,10 @@ using CG_u64_d = ConjugateGradient<uint64_t, double>;
 // ---- uint32_t / float ----
 
 // Parallel constructor
-void *cg_create_u32_pf(int fcomm, uint32_t arrSize, uint32_t maxIters, double tol)
+void *cg_create_u32_pf(int fcomm, uint32_t arrSize, uint32_t arrSizeList, uint32_t maxIters, double tol)
 {
     MPI_Comm comm = MPI_Comm_f2c(fcomm);
-    return new CG_u32_f(comm, arrSize, maxIters, tol);
+    return new CG_u32_f(comm, arrSize, arrSizeList, maxIters, tol);
 }
 
 // Destructor
@@ -21,10 +21,10 @@ void cg_destroy_u32_f(void *solver)
 }
 
 // Setup method
-void cg_setup_u32_f(void *solver, const float *inicond, const float *rhs)
+void cg_setup_u32_f(void *solver, const uint32_t *listEntries, const float *inicond, const float *rhs)
 {
     auto* cg = static_cast<CG_u32_f*>(solver);
-    cg->setup(const_cast<float*>(inicond), const_cast<float*>(rhs));
+    cg->setup(const_cast<uint32_t*>(listEntries), const_cast<float*>(inicond), const_cast<float*>(rhs));
 }
 
 // Call CG solver
@@ -59,10 +59,10 @@ void cg_get_solution_u32_f(void *solver, float* sol) {
 // ---- uint32_t / double ----
 
 // Parallel constructor
-void *cg_create_u32_pd(int fcomm, uint32_t arrSize, uint32_t maxIters, double tol)
+void *cg_create_u32_pd(int fcomm, uint32_t arrSize, uint32_t arrSizeList, uint32_t maxIters, double tol)
 {
     MPI_Comm comm = MPI_Comm_f2c(fcomm);
-    return new CG_u32_d(comm, arrSize, maxIters, tol);
+    return new CG_u32_d(comm, arrSize, arrSizeList, maxIters, tol);
 }
 
 // Destructor
@@ -72,10 +72,10 @@ void cg_destroy_u32_d(void *solver)
 }
 
 // Setup method
-void cg_setup_u32_d(void *solver, const double *inicond, const double *rhs)
+void cg_setup_u32_d(void *solver, const uint32_t *listEntries, const double *inicond, const double *rhs)
 {
     auto* cg = static_cast<CG_u32_d*>(solver);
-    cg->setup(const_cast<double*>(inicond), const_cast<double*>(rhs));
+    cg->setup(const_cast<uint32_t*>(listEntries), const_cast<double*>(inicond), const_cast<double*>(rhs));
 }
 
 // Call CG solver

--- a/src/Libs/LinAlgebra/IterSolvers/sources/IterSolvers.cpp
+++ b/src/Libs/LinAlgebra/IterSolvers/sources/IterSolvers.cpp
@@ -7,6 +7,7 @@ IterSolvers<ITYPE, RTYPE>::IterSolvers() {
     this->flag_planned = false;
     this->flag_setup = false;
     this->arrSize = 0;
+    this->arrSizeList = 0;
     this->maxIters = 0;
     this->iter = 0;
     this->tol = -1e-6;
@@ -34,12 +35,14 @@ IterSolvers<ITYPE, RTYPE>::IterSolvers() {
     this->d_resk = nullptr;
     this->aux = nullptr;
     this->d_aux = nullptr;
+    this->listEntries = nullptr;
+    this->d_listEntries = nullptr;
     POP_RANGE();
 }
 
 // Param constructor
 template <typename ITYPE, typename RTYPE>
-IterSolvers<ITYPE, RTYPE>::IterSolvers(MPI_Comm& c_comm, ITYPE arrSize, ITYPE maxIters, double tol)
+IterSolvers<ITYPE, RTYPE>::IterSolvers(MPI_Comm& c_comm, ITYPE arrSize, ITYPE arrSizeList, ITYPE maxIters, double tol)
 {
 
     PUSH_RANGE("IterSolvers::Constructor", 3);
@@ -48,7 +51,7 @@ IterSolvers<ITYPE, RTYPE>::IterSolvers(MPI_Comm& c_comm, ITYPE arrSize, ITYPE ma
     if (IterSolvers_comm.getWorldRank() == 0) std::cout << "--| IterSolvers: initializing solver" << std::endl;
 
     // Plan the solver (arrSize is per-rank!!!!)
-    plan(arrSize, maxIters, tol);
+    plan(arrSize, arrSizeList, maxIters, tol);
     if (IterSolvers_comm.getWorldRank() == 0) std::cout << "--| IterSolvers: solvers initialized!" << std::endl;
     POP_RANGE();
 }
@@ -103,13 +106,14 @@ IterSolvers<ITYPE, RTYPE>::~IterSolvers()
 
 // Param constructor
 template <typename ITYPE, typename RTYPE>
-void IterSolvers<ITYPE, RTYPE>::plan(ITYPE arrSize, ITYPE maxIters, double tol)
+void IterSolvers<ITYPE, RTYPE>::plan(ITYPE arrSize, ITYPE arrSizeList, ITYPE maxIters, double tol)
 {
     if (IterSolvers_comm.getWorldRank() == 0) std::cout << "--| IterSolvers: planning solver" << std::endl;
 
     // Allocate host memory using calloc (ensures init to 0)
     PUSH_RANGE("IterSolvers::plan", 3);
     this->arrSize = arrSize;
+    this->arrSizeList = arrSizeList;
     this->maxIters = maxIters;
     this->iter = 0;
     this->tol = tol;
@@ -156,13 +160,15 @@ void IterSolvers<ITYPE, RTYPE>::plan(ITYPE arrSize, ITYPE maxIters, double tol)
 }
 
 template <typename ITYPE, typename RTYPE>
-void IterSolvers<ITYPE, RTYPE>::setup(RTYPE *inicond, RTYPE *rhs) {
+void IterSolvers<ITYPE, RTYPE>::setup(ITYPE* listEntries, RTYPE *inicond, RTYPE *rhs) {
     // Assign initial condition and RHS
     PUSH_RANGE("IterSolvers::setup", 3);
     #ifdef USE_GPU
+        this->d_listEntries = listEntries;
         this->d_x0 = inicond;
         this->d_b = rhs;
     #else
+        this->listEntries = listEntries;
         this->x0 = inicond;
         this->b = rhs;
     #endif

--- a/src/Libs/TensorUtils/includes/TensorUtils.hpp
+++ b/src/Libs/TensorUtils/includes/TensorUtils.hpp
@@ -43,6 +43,9 @@ class TensorUtils
         // dot_product: Computes the dot product of vectors x and y
         static void dot_product(const ITYPE size, const RTYPE* x, const RTYPE* y, double* result);
 
+        // guided dot_product: Computes the dot product of vectors x and y, following a specified access pattern
+        static void guided_dot_product(const ITYPE sizeList, const ITYPE *listEntries, const RTYPE *x, const RTYPE *y, double *result);
+
         // multiply_entries: Performs element-wise multiplication of vectors x and y (y = x * y)
         static void multiply_entries(const ITYPE size, const RTYPE* x, RTYPE* y);
 

--- a/src/Libs/TensorUtils/sources/TensorUtils.cpp
+++ b/src/Libs/TensorUtils/sources/TensorUtils.cpp
@@ -36,6 +36,19 @@ void TensorUtils<ITYPE, RTYPE>::dot_product(const ITYPE size, const RTYPE* x, co
 }
 
 template <typename ITYPE, typename RTYPE>
+void TensorUtils<ITYPE, RTYPE>::guided_dot_product(const ITYPE sizeList, const ITYPE* listEntries, const RTYPE *x, const RTYPE *y, double *result)
+{
+    result[0] = static_cast<double>(0);
+    double tmp = 0.0;
+    for (ITYPE i = 0; i < sizeList; ++i)
+    {
+        ITYPE idx = listEntries[i];
+        tmp += static_cast<double>(x[idx] * y[idx]);
+    }
+    result[0] = tmp;
+}
+
+template <typename ITYPE, typename RTYPE>
 void TensorUtils<ITYPE, RTYPE>::multiply_entries(const ITYPE size, const RTYPE* x, RTYPE* y) {
     for (ITYPE i = 0; i < size; ++i) {
         y[i] *= x[i];


### PR DESCRIPTION
Closes #49 

Now GLASs uses guided dot products, which relies on a list of entries defined by the client code. Useful for handling periodicity and owned nodes in classic FEM/SEM.